### PR TITLE
Fix MP4 series part fallback and add comprehensive path generation tests

### DIFF
--- a/AudiobookManager/AudiobookManager.FileManager/TrackSpecialTagExtensions.cs
+++ b/AudiobookManager/AudiobookManager.FileManager/TrackSpecialTagExtensions.cs
@@ -84,7 +84,10 @@ public static class TrackSpecialTagExtensions
     {
         if (track.AudioFormat.Name == mp4Name)
         {
-            return track.ReadSpecialTag(SpecialTagField.Mp4SeriesPart);
+            // Prefer the custom iTunes SERIES-PART tag, but fall back to the standard
+            // Movement Part field (©mvi) for files tagged by external tools like Audiobookshelf
+            return track.ReadSpecialTag(SpecialTagField.Mp4SeriesPart)
+                ?? GetNullStringIfEmpty(track.SeriesPart);
         }
 
         return track.SeriesPart;


### PR DESCRIPTION
## Summary
This PR improves handling of series part metadata in MP4 audiobook files and adds comprehensive test coverage for audiobook path generation.

## Key Changes
- **Fixed MP4 series part reading**: Updated `TrackSpecialTagExtensions.ReadSeriesPart()` to fall back to the standard Movement Part field (©mvi) when the custom iTunes SERIES-PART tag is not available. This enables compatibility with files tagged by external tools like Audiobookshelf.
- **Added comprehensive test coverage**: Introduced 5 new test cases covering various scenarios:
  - Series with part number (full path validation)
  - Series without part number (omits book prefix)
  - Series with subtitle (subtitle in directory but not filename)
  - Decimal series part numbers (proper padding)
  - Multiple authors (correct joining)

## Implementation Details
- The fallback logic uses a null-coalescing operator to prefer the custom tag but gracefully degrade to the standard field
- `GetNullStringIfEmpty()` is used to ensure consistent null handling across both tag sources
- Test cases validate the complete relative path structure including directory hierarchy and filename formatting

https://claude.ai/code/session_019BikK1CNhpJWF7heXMSyXX