### PR TITLE
Remove subtitle from audiobook directory paths and add diff display

### DIFF
--- a/AudiobookManager/AudiobookManager.FileManager/AudiobookFileHandler.cs
+++ b/AudiobookManager/AudiobookManager.FileManager/AudiobookFileHandler.cs
@@ -61,7 +61,6 @@ public static class AudiobookFileHandler
 
         var fileName = $"{audiobook.Year} - {audiobook.BookName}";
 
-        var subtitle = string.IsNullOrEmpty(audiobook.Subtitle) ? "" : $" - {audiobook.Subtitle}";
         var pathParts = new List<string>();
         pathParts.Add(AudiobookTagHandler.GetStringFromListOfPersons(audiobook.Authors));
         if (!string.IsNullOrEmpty(audiobook.Series))
@@ -69,13 +68,13 @@ public static class AudiobookFileHandler
             pathParts.Add(audiobook.Series);
             var seriesPart = !string.IsNullOrEmpty(audiobook.SeriesPart) ? $" {AudiobookTagHandler.PadSeriesPart(audiobook.SeriesPart)}" : "";
             var seriesDirectory = !string.IsNullOrEmpty(audiobook.SeriesPart) ? $"Book{seriesPart} - " : "";
-            pathParts.Add($"{seriesDirectory}{audiobook.Year} - {audiobook.BookName}{subtitle}");
+            pathParts.Add($"{seriesDirectory}{audiobook.Year} - {audiobook.BookName}");
 
             fileName = $"{audiobook.Series}{seriesPart} - {fileName}";
         }
         else
         {
-            pathParts.Add($"{audiobook.Year} - {audiobook.BookName}{subtitle}");
+            pathParts.Add($"{audiobook.Year} - {audiobook.BookName}");
         }
 
         return CombinePathAndFilename(pathParts, fileName, Path.GetExtension(audiobook.FileInfo.FullPath));

--- a/AudiobookManager/AudiobookManager.Test/FileManager/AudiobookFileHandlerTests.cs
+++ b/AudiobookManager/AudiobookManager.Test/FileManager/AudiobookFileHandlerTests.cs
@@ -125,7 +125,7 @@ public class AudiobookFileHandlerTests
     }
 
     [TestMethod]
-    public void GenerateRelativeAudiobookPath_WithSeriesAndSubtitle_IncludesSubtitleInDirectory()
+    public void GenerateRelativeAudiobookPath_WithSeriesAndSubtitle_ExcludesSubtitleFromDirectory()
     {
         var audiobook = new Audiobook(
             new List<Person> { new Person("Author Name") },
@@ -141,8 +141,8 @@ public class AudiobookFileHandlerTests
         var result = AudiobookFileHandler.GenerateRelativeAudiobookPath(audiobook);
 
         var sep = AudiobookFileHandler.GetDirectorySeparator();
-        // Directory should include subtitle, filename should not
-        Assert.IsTrue(result.Contains($"Book 02 - 2020 - Book Title - A Subtitle{sep}"));
+        Assert.IsTrue(result.Contains($"Book 02 - 2020 - Book Title{sep}"));
+        Assert.IsFalse(result.Contains("A Subtitle"));
         Assert.IsTrue(result.EndsWith("My Series 02 - 2020 - Book Title.m4b"));
     }
 

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -11,6 +11,7 @@
         "@mdi/font": "7.4.47",
         "@quangdao/vue-signalr": "1.0.1",
         "axios": "^1.13.4",
+        "diff": "^8.0.3",
         "lodash": "4.17.23",
         "roboto-fontface": "0.10.0",
         "vue": "^3.5.27",
@@ -20,6 +21,7 @@
       },
       "devDependencies": {
         "@babel/types": "^7.28.6",
+        "@types/diff": "^7.0.2",
         "@types/lodash": "4.17.23",
         "@types/node": "^25.1.0",
         "@types/webfontloader": "1.6.38",
@@ -908,6 +910,13 @@
         "win32"
       ]
     },
+    "node_modules/@types/diff": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@types/diff/-/diff-7.0.2.tgz",
+      "integrity": "sha512-JSWRMozjFKsGlEjiiKajUjIJVKuKdE3oVy2DNtK+fUo8q82nhFZ2CPQwicAIkXrofahDXrWJ7mjelvZphMS98Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1343,6 +1352,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/diff": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.3.tgz",
+      "integrity": "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/dunder-proto": {
@@ -2875,6 +2893,12 @@
       "integrity": "sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA==",
       "optional": true
     },
+    "@types/diff": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@types/diff/-/diff-7.0.2.tgz",
+      "integrity": "sha512-JSWRMozjFKsGlEjiiKajUjIJVKuKdE3oVy2DNtK+fUo8q82nhFZ2CPQwicAIkXrofahDXrWJ7mjelvZphMS98Q==",
+      "dev": true
+    },
     "@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -3193,6 +3217,11 @@
     },
     "delayed-stream": {
       "version": "1.0.0"
+    },
+    "diff": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.3.tgz",
+      "integrity": "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ=="
     },
     "dunder-proto": {
       "version": "1.0.1",

--- a/client/package.json
+++ b/client/package.json
@@ -13,6 +13,7 @@
     "@mdi/font": "7.4.47",
     "@quangdao/vue-signalr": "1.0.1",
     "axios": "^1.13.4",
+    "diff": "^8.0.3",
     "lodash": "4.17.23",
     "roboto-fontface": "0.10.0",
     "vue": "^3.5.27",
@@ -22,6 +23,7 @@
   },
   "devDependencies": {
     "@babel/types": "^7.28.6",
+    "@types/diff": "^7.0.2",
     "@types/lodash": "4.17.23",
     "@types/node": "^25.1.0",
     "@types/webfontloader": "1.6.38",

--- a/client/src/components/DiffDisplay.vue
+++ b/client/src/components/DiffDisplay.vue
@@ -1,0 +1,68 @@
+<template>
+  <div class="diff-display">
+    <div class="diff-label">Expected:</div>
+    <div class="diff-content">
+      <template
+        v-for="(part, i) in diffParts"
+        :key="i"
+      >
+        <span
+          v-if="!part.removed"
+          :class="{ 'diff-highlight': part.added }"
+          >{{ part.value }}</span
+        >
+      </template>
+    </div>
+    <div class="diff-label">Actual:</div>
+    <div class="diff-content">
+      <template
+        v-for="(part, i) in diffParts"
+        :key="i"
+      >
+        <span
+          v-if="!part.added"
+          :class="{ 'diff-highlight': part.removed }"
+          >{{ part.value }}</span
+        >
+      </template>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from "vue";
+import { diffChars, type Change } from "diff";
+
+const props = defineProps<{
+  expected: string;
+  actual: string;
+}>();
+
+const diffParts = computed((): Change[] => {
+  return diffChars(props.actual, props.expected);
+});
+</script>
+
+<style scoped>
+.diff-display {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0 0.5em;
+  font-family: monospace;
+  font-size: 0.85em;
+}
+
+.diff-label {
+  font-weight: bold;
+  white-space: nowrap;
+}
+
+.diff-content {
+  word-break: break-all;
+}
+
+.diff-highlight {
+  background-color: rgba(255, 193, 7, 0.4);
+  border-radius: 2px;
+}
+</style>

--- a/client/src/components/DiffDisplay.vue
+++ b/client/src/components/DiffDisplay.vue
@@ -1,31 +1,14 @@
 <template>
   <div class="diff-display">
-    <div class="diff-label">Expected:</div>
-    <div class="diff-content">
-      <template
-        v-for="(part, i) in diffParts"
-        :key="i"
-      >
-        <span
-          v-if="!part.removed"
-          :class="{ 'diff-highlight': part.added }"
-          >{{ part.value }}</span
-        >
-      </template>
-    </div>
-    <div class="diff-label">Actual:</div>
-    <div class="diff-content">
-      <template
-        v-for="(part, i) in diffParts"
-        :key="i"
-      >
-        <span
-          v-if="!part.added"
-          :class="{ 'diff-highlight': part.removed }"
-          >{{ part.value }}</span
-        >
-      </template>
-    </div>
+    <span
+      v-for="(part, i) in diffParts"
+      :key="i"
+      :class="{
+        'diff-added': part.added,
+        'diff-removed': part.removed,
+      }"
+      >{{ part.value }}</span
+    >
   </div>
 </template>
 
@@ -45,24 +28,19 @@ const diffParts = computed((): Change[] => {
 
 <style scoped>
 .diff-display {
-  display: grid;
-  grid-template-columns: auto 1fr;
-  gap: 0 0.5em;
   font-family: monospace;
   font-size: 0.85em;
-}
-
-.diff-label {
-  font-weight: bold;
-  white-space: nowrap;
-}
-
-.diff-content {
   word-break: break-all;
 }
 
-.diff-highlight {
-  background-color: rgba(255, 193, 7, 0.4);
+.diff-added {
+  background-color: rgba(76, 175, 80, 0.3);
+  border-radius: 2px;
+}
+
+.diff-removed {
+  background-color: rgba(244, 67, 54, 0.3);
+  text-decoration: line-through;
   border-radius: 2px;
 }
 </style>

--- a/client/src/components/LibraryConsistency.vue
+++ b/client/src/components/LibraryConsistency.vue
@@ -112,18 +112,25 @@
                   </v-list-item-title>
                   <v-list-item-subtitle class="issue-subtitle text-wrap">
                     <div>{{ issue.description }}</div>
-                    <div
-                      v-if="issue.expectedValue"
-                      class="text-wrap"
-                    >
-                      Expected: {{ issue.expectedValue }}
-                    </div>
-                    <div
-                      v-if="issue.actualValue"
-                      class="text-wrap"
-                    >
-                      Actual: {{ issue.actualValue }}
-                    </div>
+                    <DiffDisplay
+                      v-if="issue.expectedValue && issue.actualValue"
+                      :expected="issue.expectedValue"
+                      :actual="issue.actualValue"
+                    />
+                    <template v-else>
+                      <div
+                        v-if="issue.expectedValue"
+                        class="text-wrap"
+                      >
+                        Expected: {{ issue.expectedValue }}
+                      </div>
+                      <div
+                        v-if="issue.actualValue"
+                        class="text-wrap"
+                      >
+                        Actual: {{ issue.actualValue }}
+                      </div>
+                    </template>
                   </v-list-item-subtitle>
                   <template v-slot:append>
                     <v-btn
@@ -212,6 +219,7 @@
 import { computed, Ref, ref, onMounted, reactive } from "vue";
 import ConsistencyService from "../services/ConsistencyService";
 import ConsistencyIssue from "../types/ConsistencyIssue";
+import DiffDisplay from "./DiffDisplay.vue";
 import { useSignalR, HubEventToken } from "@quangdao/vue-signalr";
 import { ConsistencyCheckProgress } from "../signalr/ConsistencyCheckProgress";
 import { ConsistencyCheckComplete } from "../signalr/ConsistencyCheckComplete";


### PR DESCRIPTION
## Summary
This PR removes subtitle information from generated audiobook directory paths and enhances the library consistency UI with a visual diff display component for comparing expected vs actual values.

## Key Changes

### Backend (AudiobookFileHandler.cs)
- Removed subtitle concatenation from audiobook directory path generation
- Subtitles are no longer included in either series or non-series directory structures
- Simplifies path generation logic by eliminating the `subtitle` variable

### Tests (AudiobookFileHandlerTests.cs)
- Updated test expectations to reflect that subtitles are now excluded from directory paths
- Renamed test method from `IncludesSubtitleInDirectory` to `ExcludesSubtitleFromDirectory` for clarity
- Added explicit assertion confirming subtitle absence in generated paths

### Frontend (Vue Components)
- **New Component**: Added `DiffDisplay.vue` component that visually highlights character-level differences between expected and actual values
  - Uses the `diff` library to compute character-level changes
  - Displays added text with green background and removed text with red strikethrough
  - Monospace font for better readability of path/filename comparisons

- **Updated Dependencies**: Added `diff` (^8.0.3) and `@types/diff` (^7.0.2) packages

- **Enhanced LibraryConsistency.vue**: Integrated `DiffDisplay` component to show visual diffs when both expected and actual values are present, improving user experience when reviewing consistency issues

## Implementation Details
The diff display component uses character-level diffing rather than line-level, making it ideal for comparing file paths and names where small differences need to be clearly visible.

https://claude.ai/code/session_01V7Vtavy1APYBrAeLm15jt7