### PR TITLE
fix: fall back to standard MP4 SeriesTitle field when custom iTunes tag is missing

### DIFF
--- a/AudiobookManager/AudiobookManager.FileManager/AudiobookTagHandler.cs
+++ b/AudiobookManager/AudiobookManager.FileManager/AudiobookTagHandler.cs
@@ -50,7 +50,7 @@ public class AudiobookTagHandler : IAudiobookTagHandler
         {
             Narrators = narrators,
             Subtitle = track.ReadSpecialTag(SpecialTagField.Subtitle),
-            Series = track.SeriesTitle,
+            Series = track.GetSeries(),
             SeriesPart = track.GetSeriesPart(),
             Genres = track.Genre.Split("/").ToList(),
             Description = track.Description,

--- a/AudiobookManager/AudiobookManager.FileManager/TrackSpecialTagExtensions.cs
+++ b/AudiobookManager/AudiobookManager.FileManager/TrackSpecialTagExtensions.cs
@@ -80,6 +80,19 @@ public static class TrackSpecialTagExtensions
         }
     }
 
+    public static string? GetSeries(this Track track)
+    {
+        if (track.AudioFormat.Name == mp4Name)
+        {
+            // Prefer the custom iTunes SERIES tag, but fall back to the standard
+            // SeriesTitle field (©mvn) for files tagged by external tools like Audiobookshelf
+            return track.ReadSpecialTag(SpecialTagField.Mp4Series)
+                ?? GetNullStringIfEmpty(track.SeriesTitle);
+        }
+
+        return track.SeriesTitle;
+    }
+
     public static string? GetSeriesPart(this Track track)
     {
         if (track.AudioFormat.Name == mp4Name)


### PR DESCRIPTION
Same pattern as the SeriesPart fix (2f5fda6): the Series tag was written to
both the custom iTunes tag (----:com.apple.iTunes:SERIES) and the standard
SeriesTitle field, but only read from the standard field. Files tagged by
external tools like Audiobookshelf that only set the custom iTunes SERIES
tag would lose the series on read. Add GetSeries() with fallback logic
matching GetSeriesPart().

https://claude.ai/code/session_01CjSNATBxg3FFiQB5BBMjTR