### PR TITLE
Convert Audiobook data to DTO before sending to API

### DIFF
--- a/client/src/services/AudiobookService.ts
+++ b/client/src/services/AudiobookService.ts
@@ -1,21 +1,44 @@
 import { Audiobook } from "../types/Audiobook";
 import BaseHttpService from "./BaseHttpService";
 
+function toDto(data: Audiobook) {
+  return {
+    authors: data.authors.map((a) => a.name),
+    narrators: data.narrators.map((n) => n.name),
+    bookName: data.bookName,
+    subtitle: data.subtitle,
+    series: data.series,
+    seriesPart: data.seriesPart,
+    year: data.year,
+    genres: data.genres,
+    description: data.description,
+    copyright: data.copyright,
+    publisher: data.publisher,
+    rating: data.rating,
+    asin: data.asin,
+    www: data.www,
+    cover: data.cover,
+    filePath: data.fileInfo?.fullPath,
+    fileName: data.fileInfo?.fileName,
+    sizeInBytes: data.fileInfo?.sizeInBytes ?? 0,
+  };
+}
+
 class AudiobookService extends BaseHttpService {
   parseBookDetails(bookPath: string): Promise<Audiobook> {
     return this.postData("/audiobook/details", { path: bookPath });
   }
 
   organizeBook(data: Audiobook): Promise<string> {
-    return this.postData("/audiobook/organize", data);
+    return this.postData("/audiobook/organize", toDto(data));
   }
 
   generateNewPath(data: Audiobook): Promise<string> {
-    return this.postData("/audiobook/generate_path", data);
+    return this.postData("/audiobook/generate_path", toDto(data));
   }
 
   updateBook(id: number, data: Audiobook): Promise<void> {
-    return this.putData(`/audiobook/${id}`, data);
+    return this.putData(`/audiobook/${id}`, toDto(data));
   }
 }
 


### PR DESCRIPTION
## Summary
Added a data transformation layer in AudiobookService to convert Audiobook domain objects to DTOs before sending them to the backend API. This ensures proper serialization of nested objects and provides a clear contract between client and server.

## Changes
- **Added `toDto()` helper function** that transforms Audiobook objects into a flat DTO structure:
  - Extracts author and narrator names from their objects (instead of sending full objects)
  - Flattens nested `fileInfo` object properties to top level
  - Provides default value (0) for `sizeInBytes` when undefined
  
- **Updated API calls** to use the new `toDto()` transformation:
  - `organizeBook()` - converts data before POST
  - `generateNewPath()` - converts data before POST
  - `updateBook()` - converts data before PUT

## Implementation Details
The DTO transformation handles the impedance mismatch between the client's Audiobook domain model (which contains nested objects like Author and FileInfo) and the API's expected flat structure. This approach keeps the transformation logic centralized and makes it easier to maintain if the API contract changes.

https://claude.ai/code/session_01V97vqmZ9tPGcNPMksQgEr2