### PR TITLE
Fix mobile navigation menu not being visible

### DIFF
--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -12,9 +12,16 @@
 
 <template>
   <v-app>
+    <v-app-bar v-if="mobile">
+      <v-app-bar-nav-icon @click="drawerOpen = !drawerOpen" />
+      <v-app-bar-title>Audiobook Manager</v-app-bar-title>
+    </v-app-bar>
+
     <v-navigation-drawer
-      expand-on-hover
-      rail
+      v-model="drawerOpen"
+      :rail="!mobile"
+      :expand-on-hover="!mobile"
+      :temporary="mobile"
     >
       <v-list
         density="compact"
@@ -76,9 +83,14 @@
 </template>
 
 <script setup lang="ts">
+import { ref } from "vue";
+import { useDisplay } from "vuetify";
 import ErrorNotifications from "./components/ErrorNotifications.vue";
 import { MenuLink } from "./types/MenuLink";
 import { useErrors } from "./components/errors";
+
+const { mobile } = useDisplay();
+const drawerOpen = ref(false);
 
 const { errors, onErrorDismissed } = useErrors();
 


### PR DESCRIPTION
On mobile, the rail drawer was hidden by Vuetify with no way to open it.
Add a v-app-bar with a hamburger toggle on mobile, and switch the drawer
to temporary mode on small screens while keeping the rail/expand-on-hover
behavior on desktop.

https://claude.ai/code/session_019ysqsagoUbAqMKYvXTKu5R