### PR TITLE
fix: update axios to v1.15.2 and fix TypeScript type error in ImageService

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1204,9 +1204,9 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
+      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
@@ -3371,9 +3371,9 @@
       "version": "0.4.0"
     },
     "axios": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
+      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
       "requires": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",

--- a/client/src/services/ImageService.ts
+++ b/client/src/services/ImageService.ts
@@ -15,7 +15,7 @@ class ImageService {
           })
           .then((response) => {
             const contentType = response.headers["content-type"];
-            if (contentType == undefined) {
+            if (typeof contentType !== "string") {
               reject("Invalid image response");
               return;
             }


### PR DESCRIPTION
Axios 1.15.2 has stricter types for response headers — headers["content-type"]
now returns `string | number | boolean | AxiosHeaders | string[]` instead of
`string | undefined`. Replace the undefined check with a typeof guard so
TypeScript narrows the type to string correctly.

https://claude.ai/code/session_01Y2hNc4mKXoiY57rJYEXnL8