### PR TITLE
Add error handling for path generation in book organization

### DIFF
--- a/client/src/components/BookOrganize.vue
+++ b/client/src/components/BookOrganize.vue
@@ -442,7 +442,11 @@ watch(
 const updateNewBookPath = debounce(async () => {
   var book = convertInputToAudiobook();
   if (book) {
-    newPath.value = await AudiobookService.generateNewPath(book);
+    try {
+      newPath.value = await AudiobookService.generateNewPath(book);
+    } catch {
+      newPath.value = "";
+    }
   }
 }, 300);
 

--- a/client/src/components/library/BookDetail.vue
+++ b/client/src/components/library/BookDetail.vue
@@ -617,7 +617,11 @@ watch(
 const updateNewBookPath = debounce(async () => {
   const book = convertInputToAudiobook();
   if (book) {
-    newPath.value = await AudiobookService.generateNewPath(book);
+    try {
+      newPath.value = await AudiobookService.generateNewPath(book);
+    } catch {
+      newPath.value = "";
+    }
   }
 }, 300);
 


### PR DESCRIPTION
## Summary
Add try-catch error handling around `AudiobookService.generateNewPath()` calls to gracefully handle failures and prevent unhandled promise rejections during book organization workflows.

## Changes
- **BookOrganize.vue**: Wrapped `AudiobookService.generateNewPath()` call in try-catch block, setting `newPath` to empty string on error
- **BookDetail.vue**: Applied identical error handling pattern to the `updateNewBookPath` debounced function

## Implementation Details
Both components' `updateNewBookPath` debounced functions now catch exceptions from the path generation service and reset the `newPath.value` to an empty string rather than allowing the error to propagate. This prevents UI state inconsistencies and provides a safer fallback when path generation fails (e.g., due to invalid metadata or service errors).

The error is silently caught without logging, allowing the UI to remain responsive while the user can correct their input and retry.

https://claude.ai/code/session_01F8ZKS6tenxQ6bGPSNnQ34S