### PR TITLE
Fix SignalR event cleanup, concurrency, and misc bugs

### DIFF
--- a/AudiobookManager/AudiobookManager.Api/Controllers/ConsistencyController.cs
+++ b/AudiobookManager/AudiobookManager.Api/Controllers/ConsistencyController.cs
@@ -11,6 +11,8 @@ namespace AudiobookManager.Api.Controllers;
 [ApiController]
 public class ConsistencyController : ControllerBase
 {
+    private static readonly SemaphoreSlim _checkLock = new(1, 1);
+
     private readonly IHubContext<OrganizeHub, IOrganize> _organizeHub;
     private readonly IServiceScopeFactory _serviceScopeFactory;
     private readonly IConsistencyIssueRepository _issueRepository;
@@ -31,13 +33,16 @@ public class ConsistencyController : ControllerBase
     [HttpPost("check")]
     public IActionResult StartConsistencyCheck()
     {
+        if (!_checkLock.Wait(0))
+            return Conflict("A consistency check is already in progress");
+
         Task.Run(async () =>
         {
-            using var scope = _serviceScopeFactory.CreateScope();
-            var consistencyService = scope.ServiceProvider.GetRequiredService<ILibraryConsistencyService>();
-
             try
             {
+                using var scope = _serviceScopeFactory.CreateScope();
+                var consistencyService = scope.ServiceProvider.GetRequiredService<ILibraryConsistencyService>();
+
                 var totalBooksChecked = 0;
                 var totalIssuesFound = 0;
 
@@ -64,6 +69,10 @@ public class ConsistencyController : ControllerBase
                 {
                     _logger.LogError(hubEx, "Failed to send ConsistencyCheckComplete over SignalR");
                 }
+            }
+            finally
+            {
+                _checkLock.Release();
             }
         });
 

--- a/AudiobookManager/AudiobookManager.Api/Controllers/LibraryController.cs
+++ b/AudiobookManager/AudiobookManager.Api/Controllers/LibraryController.cs
@@ -12,6 +12,8 @@ namespace AudiobookManager.Api.Controllers;
 [ApiController]
 public class LibraryController : ControllerBase
 {
+    private static readonly SemaphoreSlim _scanLock = new(1, 1);
+
     private readonly IHubContext<OrganizeHub, IOrganize> _organizeHub;
     private readonly IServiceScopeFactory _serviceScopeFactory;
     private readonly IDiscoveredAudiobookRepository _discoveredRepo;
@@ -32,13 +34,16 @@ public class LibraryController : ControllerBase
     [HttpPost("scan")]
     public IActionResult StartLibraryScan()
     {
+        if (!_scanLock.Wait(0))
+            return Conflict("A library scan is already in progress");
+
         Task.Run(async () =>
         {
-            using var scope = _serviceScopeFactory.CreateScope();
-            var scanService = scope.ServiceProvider.GetRequiredService<ILibraryScanService>();
-
             try
             {
+                using var scope = _serviceScopeFactory.CreateScope();
+                var scanService = scope.ServiceProvider.GetRequiredService<ILibraryScanService>();
+
                 var (totalFiles, newFilesDiscovered, trackedFiles) = await scanService.ScanLibrary(async (message, filesScanned, total) =>
                 {
                     await _organizeHub.Clients.All.LibraryScanProgress(
@@ -60,6 +65,10 @@ public class LibraryController : ControllerBase
                 {
                     _logger.LogError(hubEx, "Failed to send LibraryScanComplete over SignalR");
                 }
+            }
+            finally
+            {
+                _scanLock.Release();
             }
         });
 

--- a/AudiobookManager/AudiobookManager.Api/Controllers/SettingsController.cs
+++ b/AudiobookManager/AudiobookManager.Api/Controllers/SettingsController.cs
@@ -33,6 +33,7 @@ public class SettingsController : ControllerBase
     [HttpPut("series_mappings/{mappingId}")]
     public async Task<SeriesMapping> UpdateSeriesMappingAsync([FromBody] SeriesMapping dto, long mappingId)
     {
+        dto.Id = mappingId;
         return await _settingsService.UpdateSeriesMapping(dto);
     }
 

--- a/AudiobookManager/AudiobookManager.Api/Workers/OrganizeWorker.cs
+++ b/AudiobookManager/AudiobookManager.Api/Workers/OrganizeWorker.cs
@@ -33,7 +33,7 @@ public class OrganizeWorker : BackgroundService
                     task = await organizeTaskService.GetNextQueuedOrganizeTask();
                     if (task == null)
                     {
-                        Thread.Sleep(5000);
+                        await Task.Delay(TimeSpan.FromSeconds(5), stoppingToken);
                         continue;
                     }
 

--- a/AudiobookManager/AudiobookManager.Database/Repositories/GenreRepository.cs
+++ b/AudiobookManager/AudiobookManager.Database/Repositories/GenreRepository.cs
@@ -1,4 +1,5 @@
 ﻿using AudiobookManager.Database.Models;
+using Microsoft.EntityFrameworkCore;
 
 namespace AudiobookManager.Database.Repositories;
 public class GenreRepository : IGenreRepository
@@ -12,7 +13,7 @@ public class GenreRepository : IGenreRepository
 
     public async Task<Genre> GetOrCreateGenre(string name)
     {
-        var dbGenre = _db.Genres.SingleOrDefault(x => x.Name == name)
+        var dbGenre = await _db.Genres.SingleOrDefaultAsync(x => x.Name == name)
             ?? new Genre(default, name);
 
         if (dbGenre.Id == default)

--- a/AudiobookManager/AudiobookManager.Database/Repositories/PersonRepository.cs
+++ b/AudiobookManager/AudiobookManager.Database/Repositories/PersonRepository.cs
@@ -13,7 +13,7 @@ public class PersonRepository : IPersonRepository
 
     public async Task<Person> GetOrCreatePerson(string name)
     {
-        var dbPerson = _db.Persons.SingleOrDefault(p => p.Name == name)
+        var dbPerson = await _db.Persons.SingleOrDefaultAsync(p => p.Name == name)
             ?? new Person(default, name);
 
         if (dbPerson.Id == default)

--- a/AudiobookManager/AudiobookManager.Domain/SeriesMapping.cs
+++ b/AudiobookManager/AudiobookManager.Domain/SeriesMapping.cs
@@ -4,13 +4,13 @@ public class SeriesMapping
     public long? Id { get; set; }
     public string Regex { get; set; }
     public string MappedSeries { get; set; }
-    public bool WarnAboutParth { get; set; }
+    public bool WarnAboutPart { get; set; }
 
     public SeriesMapping(long? id, string regex, string mappedSeries, bool warnAboutParth)
     {
         Id = id;
         Regex = regex;
         MappedSeries = mappedSeries;
-        WarnAboutParth = warnAboutParth;
+        WarnAboutPart = warnAboutParth;
     }
 }

--- a/AudiobookManager/AudiobookManager.FileManager/AudiobookFileHandler.cs
+++ b/AudiobookManager/AudiobookManager.FileManager/AudiobookFileHandler.cs
@@ -46,7 +46,7 @@ public static class AudiobookFileHandler
 
     public static void RemoveDirIfEmpty(string directoryPath)
     {
-        if (Directory.Exists(directoryPath) && !Directory.GetFiles(directoryPath).Any())
+        if (Directory.Exists(directoryPath) && !Directory.GetFiles(directoryPath).Any() && !Directory.GetDirectories(directoryPath).Any())
         {
             Directory.Delete(directoryPath);
         }

--- a/AudiobookManager/AudiobookManager.Services/AudiobookService.cs
+++ b/AudiobookManager/AudiobookManager.Services/AudiobookService.cs
@@ -130,7 +130,7 @@ public class AudiobookService : IAudiobookService
             audiobook.Subtitle,
             audiobook.Series,
             audiobook.SeriesPart,
-            audiobook.Year.Value,
+            audiobook.Year ?? 0,
             audiobook.Description,
             audiobook.Copyright,
             audiobook.Publisher,
@@ -184,6 +184,7 @@ public class AudiobookService : IAudiobookService
                 throw new Exception($"'{newFullPath}' already exists");
 
             AudiobookFileHandler.RelocateAudiobook(audiobook, newFullPath);
+            audiobook.FileInfo = new AudiobookFileInfo(newFullPath, Path.GetFileName(newFullPath), audiobook.FileInfo.SizeInBytes);
             AudiobookFileHandler.RemoveDirIfEmpty(oldDirectory);
         }
 

--- a/AudiobookManager/AudiobookManager.Services/FileService.cs
+++ b/AudiobookManager/AudiobookManager.Services/FileService.cs
@@ -23,6 +23,7 @@ public class FileService : IFileService
             throw new ArgumentException(nameof(directoryPath), "Could not get directory");
         }
 
+        ValidatePathWithinAllowedBases(dir);
         Directory.Delete(dir, true);
     }
     public IList<AudiobookFileInfo> GetDirectoryContents(string directoryPath)
@@ -34,7 +35,21 @@ public class FileService : IFileService
             throw new ArgumentException(nameof(directoryPath), "Could not get directory");
         }
 
+        ValidatePathWithinAllowedBases(dir);
         return FileScanner.ScanDirectoryForFiles(dir);
+    }
+
+    private void ValidatePathWithinAllowedBases(string path)
+    {
+        var fullPath = Path.GetFullPath(path);
+        var importBase = Path.GetFullPath(_settings.AudiobookImportPath);
+        var libraryBase = Path.GetFullPath(_settings.AudiobookLibraryPath);
+
+        if (!fullPath.StartsWith(importBase, StringComparison.Ordinal) &&
+            !fullPath.StartsWith(libraryBase, StringComparison.Ordinal))
+        {
+            throw new UnauthorizedAccessException($"Access to path '{path}' is not allowed");
+        }
     }
 
     public IEnumerable<AudiobookFileInfo> ScanInputDirectoryForAudiobookFiles()

--- a/AudiobookManager/AudiobookManager.Services/MappingExtensions/SeriesMappingMapping.cs
+++ b/AudiobookManager/AudiobookManager.Services/MappingExtensions/SeriesMappingMapping.cs
@@ -3,5 +3,5 @@ public static class SeriesMappingMapping
 {
     public static Domain.SeriesMapping ToDomain(this Database.Models.SeriesMapping dbModel) => new Domain.SeriesMapping(dbModel.Id, dbModel.Regex, dbModel.MappedSeries, dbModel.WarnAboutPart);
 
-    public static Database.Models.SeriesMapping ToDb(this Domain.SeriesMapping domainModel) => new Database.Models.SeriesMapping(domainModel.Id ?? default, domainModel.Regex, domainModel.MappedSeries, domainModel.WarnAboutParth);
+    public static Database.Models.SeriesMapping ToDb(this Domain.SeriesMapping domainModel) => new Database.Models.SeriesMapping(domainModel.Id ?? default, domainModel.Regex, domainModel.MappedSeries, domainModel.WarnAboutPart);
 }

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -19,6 +19,7 @@
 
     <v-navigation-drawer
       v-model="drawerOpen"
+      :permanent="!mobile"
       :rail="!mobile"
       :expand-on-hover="!mobile"
       :temporary="mobile"

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -90,7 +90,7 @@ import { MenuLink } from "./types/MenuLink";
 import { useErrors } from "./components/errors";
 
 const { mobile } = useDisplay();
-const drawerOpen = ref(false);
+const drawerOpen = ref(!mobile.value);
 
 const { errors, onErrorDismissed } = useErrors();
 

--- a/client/src/components/BookLibrary.vue
+++ b/client/src/components/BookLibrary.vue
@@ -113,7 +113,6 @@
           <v-pagination
             v-model="discoveredCurrentPage"
             :length="discoveredTotalPages"
-            @update:model-value=""
           ></v-pagination>
         </template>
         <template v-else>
@@ -216,7 +215,6 @@
           <v-pagination
             v-model="currentPage"
             :length="totalPages"
-            @update:model-value=""
           ></v-pagination>
         </template>
         <template v-else>
@@ -233,7 +231,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, Ref, ref, watch } from "vue";
+import { computed, onMounted, onUnmounted, Ref, ref, watch } from "vue";
 import { debounce } from "lodash";
 import BookOrganize from "./BookOrganize.vue";
 import LibraryService from "../services/LibraryService";
@@ -281,22 +279,22 @@ const scanComplete: Ref<boolean> = ref(false);
 const scanNewFiles: Ref<number> = ref(0);
 const scanTrackedFiles: Ref<number> = ref(0);
 
-signalR.on(LibraryScanProgressToken, (arg) => {
+const onLibraryScanProgress = (arg: LibraryScanProgress) => {
   scanning.value = true;
   scanMessage.value = arg.message;
   scanFilesScanned.value = arg.filesScanned;
   scanTotalFiles.value = arg.totalFiles;
-});
+};
 
-signalR.on(LibraryScanCompleteToken, (arg) => {
+const onLibraryScanComplete = (arg: LibraryScanComplete) => {
   scanning.value = false;
   scanComplete.value = true;
   scanNewFiles.value = arg.newFilesDiscovered;
   scanTrackedFiles.value = arg.alreadyTracked;
   loadDiscoveredBooks();
-});
+};
 
-signalR.on(UpdateProgress, (arg) => {
+const onUpdateProgress = (arg: ProgressUpdate) => {
   const book = discoveredBooks.value.find(
     (x) => x.queueId === arg.originalFileLocation,
   );
@@ -304,15 +302,27 @@ signalR.on(UpdateProgress, (arg) => {
     book.queueMessage = arg.progressMessage;
     book.queueProgress = arg.progress;
   }
-});
+};
 
-signalR.on(QueueErrorToken, (arg) => {
+const onQueueError = (arg: QueueError) => {
   const book = discoveredBooks.value.find(
     (x) => x.queueId === arg.originalFileLocation,
   );
   if (book) {
     book.error = arg.error;
   }
+};
+
+signalR.on(LibraryScanProgressToken, onLibraryScanProgress);
+signalR.on(LibraryScanCompleteToken, onLibraryScanComplete);
+signalR.on(UpdateProgress, onUpdateProgress);
+signalR.on(QueueErrorToken, onQueueError);
+
+onUnmounted(() => {
+  signalR.off(LibraryScanProgressToken, onLibraryScanProgress);
+  signalR.off(LibraryScanCompleteToken, onLibraryScanComplete);
+  signalR.off(UpdateProgress, onUpdateProgress);
+  signalR.off(QueueErrorToken, onQueueError);
 });
 
 const totalPages = computed((): number => Math.ceil(totalItems.value / limit));

--- a/client/src/components/BookList.vue
+++ b/client/src/components/BookList.vue
@@ -59,7 +59,6 @@
           <v-pagination
             v-model="currentPage"
             :length="totalPages"
-            @update:model-value=""
           ></v-pagination>
         </template>
 
@@ -80,7 +79,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, Ref, ref, watch } from "vue";
+import { computed, onUnmounted, Ref, ref, watch } from "vue";
 import BookOrganize from "./BookOrganize.vue";
 import UntaggedService from "../services/UntaggedService";
 import QueueService from "../services/QueueService";
@@ -94,19 +93,27 @@ const QueueErrorToken: HubEventToken<QueueError> = "QueueError";
 
 const signalR = useSignalR();
 
-signalR.on(UpdateProgress, (arg) => {
+const onUpdateProgress = (arg: ProgressUpdate) => {
   const book = books.value.find((x) => x.queueId === arg.originalFileLocation);
   if (book) {
     book.queueMessage = arg.progressMessage;
     book.queueProgress = arg.progress;
   }
-});
+};
 
-signalR.on(QueueErrorToken, (arg) => {
+const onQueueError = (arg: QueueError) => {
   const book = books.value.find((x) => x.queueId === arg.originalFileLocation);
   if (book) {
     book.error = arg.error;
   }
+};
+
+signalR.on(UpdateProgress, onUpdateProgress);
+signalR.on(QueueErrorToken, onQueueError);
+
+onUnmounted(() => {
+  signalR.off(UpdateProgress, onUpdateProgress);
+  signalR.off(QueueErrorToken, onQueueError);
 });
 
 const limit = 50;
@@ -119,7 +126,7 @@ const loadingBooks: Ref<boolean> = ref(false);
 
 const totalPages = computed((): number => Math.ceil(totalItems.value / limit));
 
-watch(currentPage, (oldPage, newPage) => {
+watch(currentPage, (newPage, oldPage) => {
   loadBooks();
 });
 

--- a/client/src/components/BookOrganize.vue
+++ b/client/src/components/BookOrganize.vue
@@ -511,7 +511,7 @@ const convertInputToAudiobook = (): Audiobook | null => {
 };
 
 const validateForm = async (): Promise<boolean> => {
-  if (!form) {
+  if (!form.value) {
     return false;
   }
 
@@ -535,8 +535,12 @@ const organizeBook = async (relocate = false) => {
 
   organizing.value = true;
 
-  const organizeId = await AudiobookService.organizeBook(data);
-  emit("bookQueued", organizeId);
+  try {
+    const organizeId = await AudiobookService.organizeBook(data);
+    emit("bookQueued", organizeId);
+  } finally {
+    organizing.value = false;
+  }
 };
 const getBookDetails = async () => {
   const book = await AudiobookService.parseBookDetails(props.bookPath);

--- a/client/src/components/BookSearchDialog.vue
+++ b/client/src/components/BookSearchDialog.vue
@@ -138,7 +138,6 @@
                   <td>
                     <v-btn
                       color="primary"
-                      v-bind="props"
                       @click="chooseSeries(idx)"
                     >
                       <v-icon>mdi-check</v-icon>
@@ -213,7 +212,6 @@
                 <v-btn
                   color="primary"
                   size="small"
-                  v-bind="props"
                   @click="chooseResult(result)"
                 >
                   <v-icon>mdi-check</v-icon>
@@ -398,7 +396,7 @@ const addSearchTerm = (term: string) => {
 const { errors, onErrorDismissed } = useErrors();
 </script>
 
-<style scope>
+<style scoped>
 a {
   color: #bb86fc;
 }

--- a/client/src/components/LibraryConsistency.vue
+++ b/client/src/components/LibraryConsistency.vue
@@ -226,7 +226,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, Ref, ref, onMounted, reactive } from "vue";
+import { computed, Ref, ref, onMounted, onUnmounted, reactive } from "vue";
 import ConsistencyService from "../services/ConsistencyService";
 import ConsistencyIssue from "../types/ConsistencyIssue";
 import DiffDisplay from "./DiffDisplay.vue";
@@ -314,19 +314,27 @@ const getIssueTypeLabel = (issueType: string): string => {
   }
 };
 
-signalR.on(ConsistencyCheckProgressToken, (arg) => {
+const onConsistencyCheckProgress = (arg: ConsistencyCheckProgress) => {
   checkMessage.value = arg.message;
   checkBooksChecked.value = arg.booksChecked;
   checkTotalBooks.value = arg.totalBooks;
   checkIssuesFound.value = arg.issuesFound;
-});
+};
 
-signalR.on(ConsistencyCheckCompleteToken, (arg) => {
+const onConsistencyCheckComplete = (arg: ConsistencyCheckComplete) => {
   checking.value = false;
   checkComplete.value = true;
   completeTotalBooks.value = arg.totalBooksChecked;
   completeTotalIssues.value = arg.totalIssuesFound;
   loadIssues();
+};
+
+signalR.on(ConsistencyCheckProgressToken, onConsistencyCheckProgress);
+signalR.on(ConsistencyCheckCompleteToken, onConsistencyCheckComplete);
+
+onUnmounted(() => {
+  signalR.off(ConsistencyCheckProgressToken, onConsistencyCheckProgress);
+  signalR.off(ConsistencyCheckCompleteToken, onConsistencyCheckComplete);
 });
 
 const startCheck = async () => {

--- a/client/src/components/ManualGoodreadsUrlDialog.vue
+++ b/client/src/components/ManualGoodreadsUrlDialog.vue
@@ -79,7 +79,6 @@
                   <td>
                     <v-btn
                       color="primary"
-                      v-bind="props"
                       @click="chooseSeries(idx)"
                     >
                       <v-icon>mdi-check</v-icon>
@@ -153,7 +152,7 @@ const chooseSeries = (seriesIdx: number) => {
 const { errors, onErrorDismissed } = useErrors();
 </script>
 
-<style scope>
+<style scoped>
 a {
   color: #bb86fc;
 }

--- a/client/src/components/settings/SeriesMappingInput.vue
+++ b/client/src/components/settings/SeriesMappingInput.vue
@@ -70,7 +70,7 @@ const emit = defineEmits<{
 
 onMounted(() => {
   input.value = Object.assign(
-    { regex: "", mapped_series: "", warn_about_part: false },
+    { regex: "", mappedSeries: "", warnAboutPart: false },
     props.mapping,
   );
 });
@@ -84,7 +84,7 @@ const deleteMapping = async () => {
 };
 
 const validateForm = async (): Promise<boolean> => {
-  if (!form) {
+  if (!form.value) {
     return false;
   }
 


### PR DESCRIPTION
## Summary
This PR addresses several issues across the frontend and backend:
- **SignalR memory leaks**: Components now properly unregister event listeners on unmount
- **Concurrency control**: Library scan and consistency check endpoints now prevent concurrent execution
- **Bug fixes**: Path validation, form reference checks, typo corrections, and async/await improvements

## Key Changes

### Frontend (Vue Components)
- **BookLibrary.vue, BookList.vue, LibraryConsistency.vue**: Refactored SignalR event handlers into named functions and added `onUnmounted` hooks to properly deregister listeners, preventing memory leaks
- **BookLibrary.vue, BookList.vue**: Removed empty `@update:model-value=""` handlers from v-pagination components
- **BookOrganize.vue**: Fixed form validation to check `form.value` instead of `form`, and added try/finally to ensure `organizing` flag is reset
- **SeriesMappingInput.vue**: Fixed form reference check and corrected property names (`mapped_series` → `mappedSeries`, `warn_about_part` → `warnAboutPart`)
- **BookSearchDialog.vue, ManualGoodreadsUrlDialog.vue**: Removed erroneous `v-bind="props"` from buttons and fixed style attribute (`scope` → `scoped`)
- **App.vue**: Fixed drawer initialization to respect mobile state and added `:permanent` binding

### Backend (.NET)
- **ConsistencyController.cs, LibraryController.cs**: Added `SemaphoreSlim` locks to prevent concurrent scan/check operations; endpoints now return `Conflict` if an operation is already in progress
- **FileService.cs**: Added `ValidatePathWithinAllowedBases()` method to validate that file operations stay within allowed directories (import/library paths)
- **AudiobookService.cs**: Fixed null coalescing for `Year` property (`audiobook.Year.Value` → `audiobook.Year ?? 0`) and updated `FileInfo` after relocation
- **AudiobookFileHandler.cs**: Enhanced `RemoveDirIfEmpty()` to also check for subdirectories before deletion
- **GenreRepository.cs, PersonRepository.cs**: Changed `SingleOrDefault()` to `SingleOrDefaultAsync()` for proper async database access
- **SeriesMapping.cs**: Fixed typo (`WarnAboutParth` → `WarnAboutPart`)
- **SeriesMappingMapping.cs**: Corrected property name in mapping (`WarnAboutParth` → `WarnAboutPart`)
- **OrganizeWorker.cs**: Replaced blocking `Thread.Sleep()` with async `Task.Delay()` to respect cancellation tokens

## Notable Implementation Details
- SignalR handlers are now extracted as named arrow functions before registration, enabling proper cleanup via `signalR.off()`
- Concurrency control uses non-blocking `Wait(0)` to check lock availability without blocking the request thread
- Path validation is centralized in `FileService` and applied to both delete and read operations
- Async/await patterns improved throughout to properly support cancellation and avoid blocking thread pool threads

https://claude.ai/code/session_014QDkT79HVVhyc9qMtMehiw